### PR TITLE
이벤트 부분 수정.

### DIFF
--- a/cpp/SamchonFramework/EventListener.hpp
+++ b/cpp/SamchonFramework/EventListener.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+namespace samchon
+{
+    namespace library
+    {
+        class Event;
+
+        enum class TYPE_EVENT_LISTENER : char
+        {
+            IN = 0x01,
+            OUT = 0x02
+        };
+
+        typedef class IEventListener
+        {
+        private:
+            TYPE_EVENT_LISTENER TypeOf;
+        protected:
+            IEventListener *pNext;
+        public:
+            IEventListener(TYPE_EVENT_LISTENER type) : pNext(nullptr)
+            {
+                this->TypeOf = type;
+            }
+
+            virtual void Dispatch(Event) = 0;
+
+            friend class EventDispatcher;
+
+        }*LPIEventListener;
+    }
+}

--- a/cpp/SamchonFramework/SamchonFramework.vcxproj
+++ b/cpp/SamchonFramework/SamchonFramework.vcxproj
@@ -181,6 +181,7 @@
     <ClInclude Include="..\samchon\library\ErrorEvent.hpp" />
     <ClInclude Include="..\samchon\library\Event.hpp" />
     <ClInclude Include="..\samchon\library\EventDispatcher.hpp" />
+    <ClInclude Include="..\samchon\library\EventListener.hpp" />
     <ClInclude Include="..\samchon\library\FactorialGenerator.hpp" />
     <ClInclude Include="..\samchon\library\FTByteFile.hpp" />
     <ClInclude Include="..\samchon\library\FTFactory.hpp" />

--- a/cpp/SamchonFramework/SamchonFramework.vcxproj.filters
+++ b/cpp/SamchonFramework/SamchonFramework.vcxproj.filters
@@ -309,9 +309,6 @@
     <ClInclude Include="..\samchon\library\Event.hpp">
       <Filter>Header Files\library\event</Filter>
     </ClInclude>
-    <ClInclude Include="..\samchon\library\EventDispatcher.hpp">
-      <Filter>Header Files\library\event</Filter>
-    </ClInclude>
     <ClInclude Include="..\samchon\library\CriticalAllocator.hpp">
       <Filter>Header Files\library\critical section</Filter>
     </ClInclude>
@@ -671,6 +668,12 @@
     </ClInclude>
     <ClInclude Include="..\samchon\protocol\slave\SlaveSystemp.hpp">
       <Filter>Header Files\protocol\slave</Filter>
+    </ClInclude>
+    <ClInclude Include="..\samchon\library\EventDispatcher.hpp">
+      <Filter>Header Files\library\event</Filter>
+    </ClInclude>
+    <ClInclude Include="..\samchon\library\EventListener.hpp">
+      <Filter>Header Files\library\event</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/cpp/samchon/library/Event.hpp
+++ b/cpp/samchon/library/Event.hpp
@@ -38,11 +38,11 @@ namespace samchon
 		class SAMCHON_FRAMEWORK_API Event
 		{
 		public:
-			enum TYPES : int
+			enum TYPES : char
 			{
-				ACTIVATE = 1,
-				COMPLETE = 2,
-				REMOVED = -1
+				ACTIVATE = 0x01,
+				COMPLETE = 0x02,
+				REMOVED = 0xFF
 			};
 
 		protected:

--- a/cpp/samchon/library/EventDispatcher.cpp
+++ b/cpp/samchon/library/EventDispatcher.cpp
@@ -65,6 +65,25 @@ void EventDispatcher::removeEventListener(LPIEventListener eventListener)
     }
 }
 
+void EventDispatcher::removeEventListenerAsUUID(UUID_LISTENER uuidListener)
+{
+    UniqueWriteLock uk(mtx);
+
+    IEventListener *It = Index_Start;
+    IEventListener *tmpObject;
+
+    while (It->pNext != nullptr)
+    {
+        if (It->pNext->GetUUID() == uuidListener)
+        {
+            tmpObject = It;
+            It->pNext = tmpObject->pNext;
+
+            delete tmpObject;
+        }
+    }
+}
+
 /* -------------------------------------------------------------
 	SEND EVENT
 ------------------------------------------------------------- */

--- a/cpp/samchon/library/EventDispatcher.hpp
+++ b/cpp/samchon/library/EventDispatcher.hpp
@@ -5,7 +5,7 @@
 #include <map>
 #include <samchon/Set.hpp>
 
-#include "..\..\SamchonFramework\EventListener.hpp"
+#include <samchon/library/EventListener.hpp>
 #include <samchon/library/RWMutex.hpp>
 #include <samchon/library/Semaphore.hpp>
 
@@ -121,6 +121,7 @@ namespace samchon
 			 * @param listener The listener function to remove.
 			 */
 			void removeEventListener(LPIEventListener);
+            void removeEventListenerAsUUID(UUID_LISTENER);
 			
 		protected:
 			/* ----------------------------------------------------------

--- a/cpp/samchon/library/EventDispatcher.hpp
+++ b/cpp/samchon/library/EventDispatcher.hpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <samchon/Set.hpp>
 
+#include "..\..\SamchonFramework\EventListener.hpp"
 #include <samchon/library/RWMutex.hpp>
 #include <samchon/library/Semaphore.hpp>
 
@@ -12,6 +13,7 @@ namespace samchon
 {
 	namespace library
 	{
+
 		class Event;
 		class ErrorEvent;
 		class ProgressEvent;
@@ -46,7 +48,8 @@ namespace samchon
 			/**
 			 * @brief A container storing listeners
 			 */
-			std::map<int, std::set<void(*)(std::shared_ptr<Event>)>> eventSetMap; //EVENT
+            LPIEventListener Index_Start;
+            LPIEventListener Listeners;
 
 			/**
 			 * @brief A rw_mutex for concurrency
@@ -105,7 +108,7 @@ namespace samchon
 			 * @param type The type of event.
 			 * @param listener The listener function processes the event.
 			 */
-			void addEventListener(int, void(*listener)(std::shared_ptr<Event>));
+			void addEventListener(LPIEventListener);
 			
 			/**
 			 * @brief Remove a registered event listener
@@ -117,7 +120,7 @@ namespace samchon
 			 * @param type The type of event.
 			 * @param listener The listener function to remove.
 			 */
-			void removeEventListener(int, void(*listener)(std::shared_ptr<Event>));
+			void removeEventListener(LPIEventListener);
 			
 		protected:
 			/* ----------------------------------------------------------
@@ -134,7 +137,7 @@ namespace samchon
 			 * @param event The Event object that is dispatched into the event flow.
 			 * @return Whether there's some listener to listen the event
 			 */
-			auto dispatchEvent(std::shared_ptr<Event>) -> bool;
+			auto dispatchEvent(shared_ptr<Event>) -> bool;
 
 			/**
 			 * @brief Convenient method of dispatching a progress event

--- a/cpp/samchon/library/EventListener.hpp
+++ b/cpp/samchon/library/EventListener.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+typedef char TYPE_EVENT_LISTENER;
+
+namespace samchon
+{
+    namespace library
+    {
+        class Event;
+
+        typedef class IEventListener
+        {
+        private:
+            TYPE_EVENT_LISTENER TypeOf;
+        protected:
+            IEventListener *pNext;
+        public:
+            IEventListener(TYPE_EVENT_LISTENER type) : pNext(nullptr)
+            {
+                this->TypeOf = type;
+            }
+
+            virtual void Dispatch(Event) = 0;
+
+            friend class EventDispatcher;
+
+        }*LPIEventListener;
+    }
+}

--- a/cpp/samchon/library/EventListener.hpp
+++ b/cpp/samchon/library/EventListener.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-typedef char TYPE_EVENT_LISTENER;
+typedef char TYPE_LISTENER;
+typedef char UUID_LISTENER;
 
 namespace samchon
 {
@@ -11,19 +12,42 @@ namespace samchon
         typedef class IEventListener
         {
         private:
-            TYPE_EVENT_LISTENER TypeOf;
+            TYPE_LISTENER TypeOf;
+            UUID_LISTENER UuidOf;
         protected:
             IEventListener *pNext;
         public:
-            IEventListener(TYPE_EVENT_LISTENER type) : pNext(nullptr)
+            IEventListener(TYPE_LISTENER type, UUID_LISTENER uuid) : pNext(nullptr)
             {
                 this->TypeOf = type;
+                this->UuidOf = uuid;
             }
 
             virtual void Dispatch(Event) = 0;
 
+            UUID_LISTENER GetUUID()
+            {
+                return this->UuidOf;
+            }
+
+            TYPE_LISTENER GetType()
+            {
+                return this->TypeOf;
+            }
+
             friend class EventDispatcher;
 
         }*LPIEventListener;
+
+        template<class __listener>
+        __listener *CreateEventListender(TYPE_LISTENER type, UUID_LISTENER uuid)
+        {
+            IEventListener *pTmpClass;
+
+            if (type == 0 && uuid == 0) return nullptr;
+            pTmpClass = new __listener(type, uuid);
+
+            return pTmpClass;
+        }
     }
 }

--- a/cpp/samchon/library/ProgressEvent.hpp
+++ b/cpp/samchon/library/ProgressEvent.hpp
@@ -18,7 +18,7 @@ namespace samchon
 			: public Event
 		{
 		public:
-			enum TYPES : int
+			enum TYPES : char
 			{
 				PROGRESS = 11
 			};


### PR DESCRIPTION
1. 첫째 이벤트 리스너는 이제부터 IEventListener를 상속시킨 후에 사용할수 있습니다. 모든것들은 이 인터페이스로
통합되어 Dispatch됩니다.
2. enum 의 type이 int로 되어있는 부분을 수정했습니다. 그정도로 많은 이벤트가 필요하지 않을것이라는 판단입니다.


// 따로 문법이나 나머지 필요한것들은 따로 입맛에 맞게 재수정이 필요하오니 수정 부탁드립니다.